### PR TITLE
add missing semester column to student dashboard

### DIFF
--- a/app/views/student/dashboard/index.html.erb
+++ b/app/views/student/dashboard/index.html.erb
@@ -8,6 +8,7 @@
           <th scope="col">#</th>
           <th scope="col">Course</th>
           <th scope="col">Grade</th>
+          <th scope="col">Semester</th>
         </tr>
       </thead>
       <tbody>
@@ -16,6 +17,7 @@
             <th scope="row"><%= i += 1%></th>
             <td><%= course[:name] %></td>
             <td><%= course[:grade] %></td>
+            <td><%= course[:semester] %></td>
           </tr>
         <% end %>
       </tbody>

--- a/spec/features/student_can_view_courses_and_gpa_spec.rb
+++ b/spec/features/student_can_view_courses_and_gpa_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe "Student Dashboard" do
 
   let(:user) {create(:user, role: :student)}
   let(:teacher) {create(:user, role: :teacher)}
-  attr_reader :courses
+  attr_reader :courses, :semester, :semester2
 
   before(:each) do
-    semester = create(:semester, term: "Spring 1922", current: false)
-    semester2 = create(:semester, term: "Fall 1922", current: false)
+    @semester = create(:semester, term: "Spring 1922", current: false)
+    @semester2 = create(:semester, term: "Fall 1922", current: false)
 
     @courses = create_list(:course, 4, user_id: teacher.id)
 
@@ -34,6 +34,8 @@ RSpec.describe "Student Dashboard" do
       expect(page).to have_content("Welcome, #{user.first_name}")
       expect(page).to have_content(courses[0].name)
       expect(page).to have_content(courses[3].name)
+      expect(page).to have_content(semester.term)
+      expect(page).to have_content(semester2.term)
       expect(page).to have_content(user.enrollments.first.grade)
       expect(page).to have_content(user.enrollments.last.grade)
     end


### PR DESCRIPTION
#### What does this PR do?
Add missing Semester column on the table of courses for a logged-in student.

#### How should this be manually tested?
Login as student0@email.com and you ought to see a table with an index, course_name, grade, and semester.

#### Any background context you want to provide?

#### Questions:

  - Do Migrations Need to be ran?
* No
  - Do Environment Variables need to be set?
* No
  - Any other deploy steps?
* No